### PR TITLE
2 h2 for tests

### DIFF
--- a/DatabasePokemon/dbSetup/data/species.csv
+++ b/DatabasePokemon/dbSetup/data/species.csv
@@ -1,4 +1,4 @@
-id,name,species_id,order
+id,name,species_id,dexorder
 1,bulbasaur,1,1
 2,ivysaur,2,2
 3,venusaur,3,3

--- a/DatabasePokemon/dbSetup/setupTables.sql
+++ b/DatabasePokemon/dbSetup/setupTables.sql
@@ -2,7 +2,7 @@ CREATE TABLE species (
 	id int,
     "name" varchar(255),
     species_id int,
-	"order" int
+    dexorder int
 );
 
 CREATE TABLE species_type (

--- a/recommender/pom.xml
+++ b/recommender/pom.xml
@@ -67,7 +67,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/recommender/src/main/java/de/pokeRecommender/domain/Species.java
+++ b/recommender/src/main/java/de/pokeRecommender/domain/Species.java
@@ -21,7 +21,7 @@ public class Species implements Serializable {
 	private  int id;
 	private  int speciesId;
 	private  String name;
-	private  int order;
+	private  int dexorder;
 	@OneToMany(
 			fetch=FetchType.EAGER,cascade = CascadeType.ALL, orphanRemoval = true
 			)
@@ -36,10 +36,10 @@ public class Species implements Serializable {
 
 	}
 
-	public Species(String name, int speciesId, int order, List<Type> type) {
+	public Species(String name, int speciesId, int dexorder, List<Type> type) {
 		this.name = name;
 		this.speciesId = speciesId;
-		this.order = order;
+		this.dexorder = dexorder;
 		this.type = type;
 	}
 
@@ -51,8 +51,8 @@ public class Species implements Serializable {
 		return speciesId;
 	}
 
-	public int getOrder() {
-		return order;
+	public int getDexorder() {
+		return dexorder;
 	}
 
 	public List<Type> getType() {

--- a/recommender/src/main/resources/graphql/schema.graphqls
+++ b/recommender/src/main/resources/graphql/schema.graphqls
@@ -1,7 +1,7 @@
 type Species {
     speciesId: Int!
     name: String
-    order: Int
+    dexorder: Int
     type: [Type]
 }
 

--- a/recommender/src/test/java/de/pokeRecommender/dao/SpeciesDaoItTest.java
+++ b/recommender/src/test/java/de/pokeRecommender/dao/SpeciesDaoItTest.java
@@ -24,10 +24,9 @@ public class SpeciesDaoItTest
 	@Transactional
 	public void loadPokemon()
 	{
+		final Species pokemon = new Species("Bulba", 1, 2, null);
+		speciesdao.save(pokemon);
 		final Species pokemonSpecies = speciesdao.findBySpeciesId(1);
 		assertNotNull(pokemonSpecies);
-		assertFalse(pokemonSpecies.getType().isEmpty());;
-
-
 	}
 }

--- a/recommender/src/test/resources/application.properties
+++ b/recommender/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:~/test
+DB_CLOSE_ON_EXIT=FALSE
+MODE=PostgreSQL
+DATABASE_TO_LOWER=TRUE
+DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=sa


### PR DESCRIPTION
Adds H2 as in-memory DB for tests. SQL Table creation for tests is inferred from entities which leads to SQL keyword collision for column "order" because of H2 parser.  Related Posts/Issues:  

- []()https://stackoverflow.com/questions/19758467/h2-database-column-name-group-is-a-reserved-word

- []()https://github.com/h2database/h2database/issues/1719

- []()https://stackoverflow.com/questions/46737430/hibernate-h2-embeddable-list-expected-identifier

Therefore attribute order has been refactored to "dexorder" which also further reflects the meaning of the attribute as stated in pokeapi doc: 

> The order in which species should be sorted. Based on National Dex order, except families are grouped together and sorted by stage

How to test: check basic functionality, run speciesDao test :)
